### PR TITLE
Fix missing 'this' qualifier

### DIFF
--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -208,7 +208,7 @@ namespace Postgrest
         /// <returns></returns>
         public Table<T> And(List<QueryFilter> filters)
         {
-            filters.Add(new QueryFilter(Operator.And, filters));
+            this.filters.Add(new QueryFilter(Operator.And, filters));
             return this;
         }
 
@@ -219,7 +219,7 @@ namespace Postgrest
         /// <returns></returns>
         public Table<T> Or(List<QueryFilter> filters)
         {
-            filters.Add(new QueryFilter(Operator.Or, filters));
+            this.filters.Add(new QueryFilter(Operator.Or, filters));
             return this;
         }
 


### PR DESCRIPTION
The 'or' and 'and' filters were not being applied to a table when selecting. The 'this' qualifier was missing which was only adding the filters to the parameter rather than the instance.