### PR TITLE
Fixing zero length content when sending requests without body

### DIFF
--- a/Postgrest/Helpers.cs
+++ b/Postgrest/Helpers.cs
@@ -80,7 +80,7 @@ namespace Postgrest
 
             using var requestMessage = new HttpRequestMessage(method, builder.Uri);
 
-            if (data != null && method != HttpMethod.Get)
+            if (!string.IsNullOrWhiteSpace(data as string) && method != HttpMethod.Get)
             {
                 requestMessage.Content = new StringContent(JsonConvert.SerializeObject(data, serializerSettings),
                     Encoding.UTF8, "application/json");

--- a/Postgrest/Helpers.cs
+++ b/Postgrest/Helpers.cs
@@ -7,6 +7,7 @@ using System.Web;
 using Newtonsoft.Json;
 using Postgrest.Responses;
 using System.Runtime.CompilerServices;
+using Newtonsoft.Json.Linq;
 using Postgrest.Extensions;
 
 [assembly: InternalsVisibleTo("PostgrestTests")]
@@ -80,10 +81,15 @@ namespace Postgrest
 
             using var requestMessage = new HttpRequestMessage(method, builder.Uri);
 
-            if (!string.IsNullOrWhiteSpace(data as string) && method != HttpMethod.Get)
+            if (data != null && method != HttpMethod.Get)
             {
-                requestMessage.Content = new StringContent(JsonConvert.SerializeObject(data, serializerSettings),
-                    Encoding.UTF8, "application/json");
+                var stringContent = JsonConvert.SerializeObject(data, serializerSettings);
+
+                if (!string.IsNullOrWhiteSpace(stringContent) && JToken.Parse(stringContent).HasValues)
+                {
+                    requestMessage.Content = new StringContent(stringContent,
+                        Encoding.UTF8, "application/json");
+                }
             }
 
             if (headers != null)


### PR DESCRIPTION
This fixes an issue when calling the Count function on a table/view