### PR TITLE
Add specification of EmbedType (join type) to ReferenceAttribute

### DIFF
--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -500,7 +500,7 @@ namespace Postgrest
             }
 
             method = HttpMethod.Delete;
-            
+
             Match(model);
 
             var request = Send<T>(method, null, options.ToHeaders(), cancellationToken);
@@ -666,7 +666,16 @@ namespace Postgrest
                     if (reference.IncludeInQuery)
                     {
                         var columns = string.Join(",", reference.Columns.ToArray());
-                        query["select"] = query["select"] + $",{reference.TableName}!inner({columns})";
+
+                        switch (reference.EmbedType)
+                        {
+                            case ReferenceAttribute.EmbedQueryType.Standard:
+                                query["select"] = query["select"] + $",{reference.TableName}({columns})";
+                                break;
+                            case ReferenceAttribute.EmbedQueryType.Inner:
+                                query["select"] = query["select"] + $",{reference.TableName}!inner({columns})";
+                                break;
+                        }
                     }
                 }
             }

--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -667,14 +667,13 @@ namespace Postgrest
                     {
                         var columns = string.Join(",", reference.Columns.ToArray());
 
-                        switch (reference.EmbedType)
+                        if (reference.ShouldFilterTopLevel)
                         {
-                            case ReferenceAttribute.EmbedQueryType.Standard:
-                                query["select"] = query["select"] + $",{reference.TableName}({columns})";
-                                break;
-                            case ReferenceAttribute.EmbedQueryType.Inner:
-                                query["select"] = query["select"] + $",{reference.TableName}!inner({columns})";
-                                break;
+                            query["select"] = query["select"] + $",{reference.TableName}!inner({columns})";
+                        }
+                        else
+                        {
+                            query["select"] = query["select"] + $",{reference.TableName}({columns})";
                         }
                     }
                 }


### PR DESCRIPTION
Ref #50.

Adds `embedType` as constructor parameter for `ReferenceAttribute` with the default to `EmbedQueryType.Inner` to match current API expectations.

Example: 
```c#
[Reference(typeof(Person), embedType: EmbedQueryType.Standard)]
public List<Person> Persons { get; set; }
```
Setting `EmbedQueryType.Standard` will remove Top Level Filtering from returned results.

See: https://postgrest.org/en/stable/api.html#embedded-filters