### PR TITLE
change Table<> To Table<>()  in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ In Short:
 ```c#
 // What was:
 var client = Client.Initialize(baseUrl, options);
-var query = await client.Table<User>.Single();
+var query = await client.Table<User>().Single();
 
 // Becomes:
 var client = new Client(baseUrl, options);
-var query = await client.Table<User>.Single();
+var query = await client.Table<User>().Single();
 ```
 
 ---


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update: Updated ReadMe, Rewrote ```Table<User>.Single()```  to ```Table<User>().Single()```

## What is the current behavior?

---

## What is the new behavior?

---

## Additional context

---
