### PR TITLE
Minor Unity Related Fixes

### DIFF
--- a/Postgrest/Exceptions/FailureHint.cs
+++ b/Postgrest/Exceptions/FailureHint.cs
@@ -15,7 +15,7 @@ namespace Postgrest.Exceptions
 			NotAuthorized,
 			ForeignKeyViolation,
 			UniquenessViolation,
-			Internal,
+			ServerError,
 			UndefinedTable,
 			UndefinedFunction,
 			InvalidArgument
@@ -34,7 +34,7 @@ namespace Postgrest.Exceptions
 				404 when pgex.Content.Contains("42P01") => UndefinedFunction,
 				409 when pgex.Content.Contains("23503") => ForeignKeyViolation,
 				409 when pgex.Content.Contains("23505") => UniquenessViolation,
-				500 => Internal,
+				500 => ServerError,
 				_ => Unknown
 			};
 		}

--- a/Postgrest/Helpers.cs
+++ b/Postgrest/Helpers.cs
@@ -21,7 +21,7 @@ namespace Postgrest
 	{
 		private static readonly HttpClient Client = new HttpClient();
 
-		private static Guid _appSession = Guid.NewGuid();
+		private static readonly Guid AppSession = Guid.NewGuid();
 
 		/// <summary>
 		/// Helper to make a request using the defined parameters to an API Endpoint and coerce into a model. 
@@ -138,7 +138,7 @@ namespace Postgrest
 
 			if (!headers.ContainsKey("X-Client-Info"))
 			{
-				headers.Add("X-Client-Info", $"Client {_appSession}");
+				headers.Add("X-Client-Info", $"Client {AppSession}");
 			}
 
 			return headers;

--- a/Postgrest/Helpers.cs
+++ b/Postgrest/Helpers.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using Postgrest.Exceptions;
 using Postgrest.Models;
 using Postgrest.Responses;
+using Supabase.Core;
 using Supabase.Core.Extensions;
 [assembly: InternalsVisibleTo("PostgrestTests")]
 
@@ -138,7 +139,18 @@ namespace Postgrest
 
 			if (!headers.ContainsKey("X-Client-Info"))
 			{
-				headers.Add("X-Client-Info", $"Client {AppSession}");
+				try
+				{
+					// Default version to match other clients
+					// https://github.com/search?q=org%3Asupabase-community+x-client-info&type=code
+					headers.Add("X-Client-Info", $"postgrest-csharp/{Util.GetAssemblyVersion(typeof(Client))}");
+				}
+				catch (Exception)
+				{
+					// Fallback for when the version can't be found
+					// e.g. running in the Unity Editor, ILL2CPP builds, etc.
+					headers.Add("X-Client-Info", $"postgrest-csharp/session-{AppSession}");
+				}
 			}
 
 			return headers;

--- a/Postgrest/Helpers.cs
+++ b/Postgrest/Helpers.cs
@@ -11,7 +11,6 @@ using Newtonsoft.Json.Linq;
 using Postgrest.Exceptions;
 using Postgrest.Models;
 using Postgrest.Responses;
-using Supabase.Core;
 using Supabase.Core.Extensions;
 [assembly: InternalsVisibleTo("PostgrestTests")]
 
@@ -21,6 +20,8 @@ namespace Postgrest
 	internal static class Helpers
 	{
 		private static readonly HttpClient Client = new HttpClient();
+
+		private static Guid _appSession = Guid.NewGuid();
 
 		/// <summary>
 		/// Helper to make a request using the defined parameters to an API Endpoint and coerce into a model. 
@@ -137,7 +138,7 @@ namespace Postgrest
 
 			if (!headers.ContainsKey("X-Client-Info"))
 			{
-				headers.Add("X-Client-Info", Util.GetAssemblyVersion(typeof(Client)));
+				headers.Add("X-Client-Info", $"Client {_appSession}");
 			}
 
 			return headers;

--- a/Postgrest/Models/BaseModel.cs
+++ b/Postgrest/Models/BaseModel.cs
@@ -43,7 +43,7 @@ namespace Postgrest.Models
 		public virtual Task Delete<T>(CancellationToken cancellationToken = default) where T : BaseModel, new()
 		{
 			if (BaseUrl == null)
-				throw new PostgrestException("`BaseUrl` should be set in the model.") { Reason = FailureHint.Reason.Internal };
+				throw new PostgrestException("`BaseUrl` should be set in the model.") { Reason = FailureHint.Reason.ServerError };
 
 			var client = new Client(BaseUrl, RequestClientOptions)
 			{


### PR DESCRIPTION
## What kind of change does this PR introduce?

1. The Internal enum value is causing an error in Unity "Error CS0118 : 'Internal' is a namespace but is used like a variable".  PR renames it to a semantically identical name that's less likely to cause a conflict.
2. GetAssemblyVersion is used to set X-Client-Info for the requests if the header is not already set. This call to GetAssemblyVersion fails on Unity with a null reference. Replaced this with a Guid set for the app run - this will likely be more helpful for debugging (e.g. tracking down a choreography of requests in a logging solution).