### PR TITLE
Fix Where clause with enum supabase-community/supabase-csharp#66

### DIFF
--- a/PostgrestTests/LinqTests.cs
+++ b/PostgrestTests/LinqTests.cs
@@ -98,6 +98,21 @@ namespace PostgrestTests
             foreach (var q in query7.Models)
                 Assert.IsNotNull(q.DateTimeValue);
 
+            //Testing where condition with Enum as constant
+            var query8 = await client.Table<Movie>()
+                .Where(x => x.Status == MovieStatus.OnDisplay)
+                .Get();
+            foreach (var q in query8.Models)
+                Assert.IsTrue(q.Status == MovieStatus.OnDisplay);
+
+            //Test where condition with Enum as Memeber expression
+            var testMovie = new Movie { Status = MovieStatus.OnDisplay };
+            var query9 = await client.Table<Movie>()
+                .Where(x => x.Status == testMovie.Status)
+                .Get();
+            foreach (var q in query9.Models)
+                Assert.IsTrue(q.Status == MovieStatus.OnDisplay);
+
             await client.Table<KitchenSink>()
                 .Where(x => x.DateTimeValue == DateTime.Now)
                 .Get();

--- a/PostgrestTests/Models/LinkedModels.cs
+++ b/PostgrestTests/Models/LinkedModels.cs
@@ -12,10 +12,18 @@ public class Movie : BaseModel
 
     [Column("name")] public string? Name { get; set; }
 
+    [Column("status")] public MovieStatus? Status { get; set; }
+
     [Reference(typeof(Person), ReferenceAttribute.JoinType.Left)]
     public List<Person> People { get; set; } = new();
 
     [Column("created_at")] public DateTime CreatedAt { get; set; }
+}
+
+public enum MovieStatus
+{
+    OnDisplay,
+    OffDisplay
 }
 
 [Table("person")]

--- a/PostgrestTests/db/00-schema.sql
+++ b/PostgrestTests/db/00-schema.sql
@@ -75,7 +75,8 @@ CREATE TABLE public.movie
 (
     id         uuid                                 DEFAULT gen_random_uuid() PRIMARY KEY,
     created_at timestamp without time zone NOT NULL DEFAULT now(),
-    name       character varying(255)      NULL
+    name       character varying(255)      NULL,
+    status     character varying(255)      NULL
 );
 
 CREATE TABLE public.person

--- a/PostgrestTests/db/01-dummy-data.sql
+++ b/PostgrestTests/db/01-dummy-data.sql
@@ -53,12 +53,12 @@ VALUES ('f3ff356d-5803-43a7-b125-ba10cf10fdcd',
         '[20,50]'::int4range);
 
 
-insert into "public"."movie" ("created_at", "id", "name")
-values ('2022-08-20 00:29:45.400188', 'ea07bd86-a507-4c68-9545-b848bfe74c90', 'Top Gun: Maverick');
-insert into "public"."movie" ("created_at", "id", "name")
-values ('2022-08-22 00:29:45.400188', 'a972a8f6-2e23-4172-be8d-7b65470ca0f4', 'Mad Max: Fury Road');
-insert into "public"."movie" ("created_at", "id", "name")
-values ('2022-08-28 00:29:45.400188', '42fd15b1-3bff-431d-9fa5-314289beb246', 'Guns Away');
+insert into "public"."movie" ("created_at", "id", "name", "status")
+values ('2022-08-20 00:29:45.400188', 'ea07bd86-a507-4c68-9545-b848bfe74c90', 'Top Gun: Maverick', 'OnDisplay');
+insert into "public"."movie" ("created_at", "id", "name", "status")
+values ('2022-08-22 00:29:45.400188', 'a972a8f6-2e23-4172-be8d-7b65470ca0f4', 'Mad Max: Fury Road', 'OnDisplay');
+insert into "public"."movie" ("created_at", "id", "name", "status")
+values ('2022-08-28 00:29:45.400188', '42fd15b1-3bff-431d-9fa5-314289beb246', 'Guns Away', 'OffDisplay');
 
 
 insert into "public"."person" ("created_at", "first_name", "id", "last_name")


### PR DESCRIPTION
## What kind of change does this PR introduce?
supabase-community/supabase-csharp#66
Fix this [bug](https://github.com/supabase-community/supabase-csharp/issues/66) when trying to perform a Where using enums

## What is the current behavior?

Not working. A workaround using the EnumMember attribute to get the value and use it with Filter method

## What is the new behavior?
As described in the bug. Being able to use Enums in the where clause.

