### PR TITLE
Fix issue with marshalling of stored procedure arguments

### DIFF
--- a/Postgrest/Client.cs
+++ b/Postgrest/Client.cs
@@ -95,9 +95,9 @@ namespace Postgrest
 			var serializerSettings = SerializerSettings(Options);
 
 			// Prepare parameters
-			Dictionary<string, string>? data = null;
+			Dictionary<string, object>? data = null;
 			if (parameters != null)
-				data = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(parameters, serializerSettings));
+				data = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(parameters, serializerSettings));
 
 			// Prepare headers
 			var headers = Helpers.PrepareRequestHeaders(HttpMethod.Post, new Dictionary<string, string>(Options.Headers), Options);

--- a/Postgrest/Client.cs
+++ b/Postgrest/Client.cs
@@ -85,7 +85,7 @@ namespace Postgrest
 
 
 		/// <inheritdoc />
-		public Task<BaseResponse> Rpc(string procedureName, Dictionary<string, object>? parameters = null)
+		public Task<BaseResponse> Rpc(string procedureName, object? parameters = null)
 		{
 			// Build Uri
 			var builder = new UriBuilder($"{BaseUrl}/rpc/{procedureName}");

--- a/Postgrest/Interfaces/IPostgrestClient.cs
+++ b/Postgrest/Interfaces/IPostgrestClient.cs
@@ -44,7 +44,7 @@ namespace Postgrest.Interfaces
 		/// <param name="procedureName">The function name to call</param>
 		/// <param name="parameters">The parameters to pass to the function call</param>
 		/// <returns></returns>
-		Task<BaseResponse> Rpc(string procedureName, Dictionary<string, object> parameters);
+		Task<BaseResponse> Rpc(string procedureName, object? parameters);
 
 		/// <summary>
 		/// Returns a Table Query Builder instance for a defined model - representative of `USE $TABLE`

--- a/Postgrest/Postgrest.csproj
+++ b/Postgrest/Postgrest.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.0;</TargetFramework>
         <LangVersion>9.0</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
         <Nullable>enable</Nullable>

--- a/PostgrestTests/ClientTests.cs
+++ b/PostgrestTests/ClientTests.cs
@@ -1062,6 +1062,31 @@ namespace PostgrestTests
             Assert.AreEqual(true, response.Content?.Contains("OFFLINE"));
         }
 
+        [TestMethod("stored procedure with row param")]
+        public async Task TestStoredProcedureWithRowParam()
+        {
+            //Arrange 
+            var client = new Client(BaseUrl);
+
+            //Act 
+            var parameters = new Dictionary<string, object>
+            {
+                {
+                    "param",
+                    new Dictionary<string, object>
+                    {
+                        { "username", "supabot" }
+                    }
+                }
+            };
+            var response = await client.Rpc("get_data", parameters);
+
+            //Assert 
+            Assert.AreEqual(true, response.ResponseMessage?.IsSuccessStatusCode);
+            Assert.AreEqual("null", response.Content);
+        }
+
+
         [TestMethod("switch schema")]
         public async Task TestSwitchSchema()
         {

--- a/PostgrestTests/db/00-schema.sql
+++ b/PostgrestTests/db/00-schema.sql
@@ -110,6 +110,15 @@ from users
 WHERE username = name_param;
 $$ LANGUAGE SQL IMMUTABLE;
 
+-- STORED FUNCTION WITH ROW PARAMETER
+CREATE FUNCTION public.get_data(param public.users)
+    RETURNS public.users.data%TYPE AS
+$$
+SELECT data
+from users u
+WHERE u.username = param.username;
+$$ LANGUAGE SQL IMMUTABLE;
+
 -- SECOND SCHEMA USERS
 CREATE TYPE personal.user_status AS ENUM ('ONLINE', 'OFFLINE');
 CREATE TABLE personal.users
@@ -130,3 +139,13 @@ SELECT status
 from users
 WHERE username = name_param;
 $$ LANGUAGE SQL IMMUTABLE;
+
+-- SECOND SCHEMA STORED FUNCTION WITH ROW PARAMETER
+CREATE FUNCTION personal.get_data(param personal.users)
+    RETURNS personal.users.data%TYPE AS
+$$
+SELECT data
+from users u
+WHERE u.username = param.username;
+$$ LANGUAGE SQL IMMUTABLE;
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - db
   db:
     image: postgres:14
-    ports:
-      - "127.0.0.1:5432:5432"
+    #ports:
+    #- "127.0.0.1:5432:5432"
     volumes:
       - ./PostgrestTests/db:/docker-entrypoint-initdb.d/
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   rest:
     image: postgrest/postgrest:latest
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       PGRST_DB_URI: postgres://postgres:postgres@db:5432/postgres
       PGRST_DB_SCHEMA: public, personal
@@ -14,7 +14,7 @@ services:
   db:
     image: postgres:14
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - ./PostgrestTests/db:/docker-entrypoint-initdb.d/
     environment:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Addresses issue #74 

## What is the current behavior?

Data are forced into a `Dictionary<string, string>` before sending them to PostgREST. This doesn't work for nested data.

## What is the new behavior?

~~The `Dictionary<string, string>` is changed to `Dictionary<string, object>`~~

The `Dictionary<string, string>` is changed to `object` (so that any class can be passed without needing to convert to `Dictonary`)
