### PR TITLE
fix: #85

### DIFF
--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -668,13 +668,18 @@ namespace Postgrest
 
                     if (order.Length > 0)
                         order.Append(",");
-                    order.Append($"{(!string.IsNullOrEmpty(orderer.ForeignTable) ? orderer.ForeignTable + "(" + orderer.Column + ")" : orderer.Column)}.{orderingAttr.Mapping}.{nullPosAttr.Mapping}");
+
+                    var selector = !string.IsNullOrEmpty(orderer.ForeignTable)
+                        ? orderer.ForeignTable + "(" + orderer.Column + ")"
+                        : orderer.Column;
+                    
+                    order.Append($"{selector}.{orderingAttr.Mapping}.{nullPosAttr.Mapping}");
                 }
 
-				query.Add("order", order.ToString());
-			}
+                query.Add("order", order.ToString());
+            }
 
-			if (!string.IsNullOrEmpty(_columnQuery))
+            if (!string.IsNullOrEmpty(_columnQuery))
                 query["select"] = Regex.Replace(_columnQuery!, @"\s", "");
 
             if (_references.Count > 0)

--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -655,18 +655,26 @@ namespace Postgrest
             foreach (var parsedFilter in _filters.Select(PrepareFilter))
                 query.Add(parsedFilter.Key, parsedFilter.Value);
 
-            foreach (var orderer in _orderers)
+            if (_orderers.Count > 0)
             {
-                var nullPosAttr = orderer.NullPosition.GetAttribute<MapToAttribute>();
-                var orderingAttr = orderer.Ordering.GetAttribute<MapToAttribute>();
+                var order = new StringBuilder();
 
-                if (nullPosAttr == null || orderingAttr == null) continue;
+                foreach (var orderer in _orderers)
+                {
+                    var nullPosAttr = orderer.NullPosition.GetAttribute<MapToAttribute>();
+                    var orderingAttr = orderer.Ordering.GetAttribute<MapToAttribute>();
 
-                var key = !string.IsNullOrEmpty(orderer.ForeignTable) ? $"{orderer.ForeignTable}.order" : "order";
-                query.Add(key, $"{orderer.Column}.{orderingAttr.Mapping}.{nullPosAttr.Mapping}");
-            }
+                    if (nullPosAttr == null || orderingAttr == null) continue;
 
-            if (!string.IsNullOrEmpty(_columnQuery))
+                    if (order.Length > 0)
+                        order.Append(",");
+                    order.Append($"{(!string.IsNullOrEmpty(orderer.ForeignTable) ? orderer.ForeignTable + "(" + orderer.Column + ")" : orderer.Column)}.{orderingAttr.Mapping}.{nullPosAttr.Mapping}");
+                }
+
+				query.Add("order", order.ToString());
+			}
+
+			if (!string.IsNullOrEmpty(_columnQuery))
                 query["select"] = Regex.Replace(_columnQuery!, @"\s", "");
 
             if (_references.Count > 0)

--- a/PostgrestTests/ClientTests.cs
+++ b/PostgrestTests/ClientTests.cs
@@ -440,7 +440,7 @@ namespace PostgrestTests
 
             linqOrderedUsers = unorderedResponse.Models
                 .OrderByDescending(u => u.Username)
-                .OrderByDescending(u => u.Status)
+                .ThenByDescending(u => u.Status)
                 .ToList();
 
             CollectionAssert.AreEqual(linqOrderedUsers, multipleOrderedResponse.Models);

--- a/PostgrestTests/ClientTests.cs
+++ b/PostgrestTests/ClientTests.cs
@@ -424,13 +424,26 @@ namespace PostgrestTests
         {
             var client = new Client(BaseUrl);
 
+            // Test with a single orderer specified
             var orderedResponse = await client.Table<User>().Order("username", Ordering.Descending).Get();
             var unorderedResponse = await client.Table<User>().Get();
 
-            var supaOrderedUsers = orderedResponse.Models;
             var linqOrderedUsers = unorderedResponse.Models.OrderByDescending(u => u.Username).ToList();
 
-            CollectionAssert.AreEqual(linqOrderedUsers, supaOrderedUsers);
+            CollectionAssert.AreEqual(linqOrderedUsers, orderedResponse.Models);
+
+            // Test with multiple orderers specified
+            var multipleOrderedResponse = await client.Table<User>()
+                .Order(u => u.Username!, Ordering.Descending)
+                .Order(u => u.Status!, Ordering.Descending)
+                .Get();
+
+            linqOrderedUsers = unorderedResponse.Models
+                .OrderByDescending(u => u.Username)
+                .OrderByDescending(u => u.Status)
+                .ToList();
+
+            CollectionAssert.AreEqual(linqOrderedUsers, multipleOrderedResponse.Models);
         }
 
         [TestMethod("limit: basic")]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

#85 

## What is the new behavior?

Modified Postgrest.Table<TModel>.GenerateUrl() to produce a single order query parameter with comma-separated expressions for each chained .Order() method rather than producing a separate order query parameter for each.

## Additional context

The changes resolved the issue #85, although its uncertain whether the changes are correctly made for ordering by foreign table columns.
