### PR TITLE
Fix set null value on string property

### DIFF
--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -474,13 +474,13 @@ namespace Supabase.Postgrest
                 throw new ArgumentException(
                     "Expression should return a KeyValuePair with a key of a Model Property and a value.");
 
-            if (value == null)
+            if (value == null && visitor.ExpectedType != typeof(string))
             {
                 if (Nullable.GetUnderlyingType(visitor.ExpectedType) == null)
                     throw new ArgumentException(
                         $"Expected Value to be of Type: {visitor.ExpectedType.Name}, instead received: {null}.");
             }
-            else if (!visitor.ExpectedType.IsInstanceOfType(value))
+            else if (value != null && !visitor.ExpectedType.IsInstanceOfType(value))
             {
                 throw new ArgumentException(string.Format("Expected Value to be of Type: {0}, instead received: {1}.",
                     visitor.ExpectedType.Name, value.GetType().Name));

--- a/PostgrestTests/LinqTests.cs
+++ b/PostgrestTests/LinqTests.cs
@@ -129,6 +129,10 @@ namespace PostgrestTests
             await client.Table<KitchenSink>()
                 .Set(x => x.BooleanValue, true)
                 .Update();
+
+            await client.Table<KitchenSink>()
+                .Set(x => x.StringValue!, null)
+                .Update();
         }
 
         [TestMethod("Linq: OnConflict")]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR skip the null check on the expected type of a table column if it's a string.

## What is the current behavior?

Because reflexion does not make difference between string and string?, updating text column with a null value failed :
```
System.ArgumentException: Expected Value to be of Type: String, instead received: .
at Supabase.Postgrest.Table`1.Set(Expression`1 keySelector, Object value)
```

## What is the new behavior?

If a new value is of type string, the null check is bypassed.

## Additional context

This should be improved with NullabilityInfoContext (https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#libraries-reflection-apis-for-nullability-information), but not available with netstandard2.0
